### PR TITLE
Update to v3 url and more transparent logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ You may want to check out https://tools.letsdebug.net/clear-authz instead. It ru
 
 ## Installation
 
-Please download the Linux amd64 binary from the releases page. Otherwise, you are on your own to build it from source:
+This is easiest to install using `go get` like so:
 
-    go get -u github.com/alexzorin/clear-authz
+    go get -u github.com/edlio/clear-authz
+
+Alternatively, you can cross-compile for amd64 if you wish to build from source:
+
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o clear-authz -v clear-authz.go
 
 ## Usage
 

--- a/clear-authz.go
+++ b/clear-authz.go
@@ -44,7 +44,7 @@ func main() {
 	}
 	log.Printf("Using %s for private key for %s", keyPath, v1Server)
 
-	pattern := regexp.MustCompile("https://" + regexp.QuoteMeta(v1Server) + "/acme/authz/[a-zA-Z0-9_-]+")
+	pattern := regexp.MustCompile("https://" + regexp.QuoteMeta(v1Server) + "/acme/authz-v3/[a-zA-Z0-9_-]+")
 
 	pkBuf, err := ioutil.ReadFile(keyPath)
 	if err != nil {
@@ -87,6 +87,7 @@ func main() {
 		}
 
 		if authz.Status != "pending" {
+			log.Printf("authz url '%s' is not pending", authURL)
 			continue
 		}
 


### PR DESCRIPTION
We updated the regexp to search specifically for the new authz-v3 url that is generated when requesting a challenge.

Additionally, we wanted to know on subsequent runs, exactly which urls aren't pending.